### PR TITLE
Patches the MathJax reference

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -43,7 +43,7 @@ class Plugin extends PluginBase
     public function boot()
     {
         PostsController::extend(function ($controller) {
-            $controller->addJs("//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML");
+            $controller->addJs("//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML");
             $controller->addJs("/plugins/mossadal/mathjax/assets/js/mathjax.js");
         });
     }

--- a/Plugin.php
+++ b/Plugin.php
@@ -43,7 +43,7 @@ class Plugin extends PluginBase
     public function boot()
     {
         PostsController::extend(function ($controller) {
-            $controller->addJs("//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML");
+            $controller->addJs("//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML");
             $controller->addJs("/plugins/mossadal/mathjax/assets/js/mathjax.js");
         });
     }


### PR DESCRIPTION
This update patches the MathJax reference so that it points to the new CDN, in accordance with this update: https://www.mathjax.org/cdn-shutting-down/